### PR TITLE
Integrate input validation into CLI commands

### DIFF
--- a/crates/termbrain-cli/Cargo.toml
+++ b/crates/termbrain-cli/Cargo.toml
@@ -22,3 +22,4 @@ serde_json.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5.0"
 uuid = { version = "1.0", features = ["v4"] }
+hostname = "0.4"


### PR DESCRIPTION
## Summary
This PR integrates the input validation module into CLI commands to ensure all user inputs are properly validated before processing.

## Changes
- Integrate validation in `record_command` function
- Integrate validation in `search_commands` function
- Add hostname crate dependency for system hostname retrieval
- Add warnings for invalid metadata (shell, username, hostname)

## Validation Applied

### record_command
- Command string validation (length, null bytes, control chars)
- Directory path validation and normalization
- Shell name validation (with warning on failure)
- Username validation (with warning on failure)
- Hostname validation (with warning on failure)

### search_commands
- Query non-empty validation
- Directory path validation if provided

## Dependencies
- Added `hostname = "0.4"` to get system hostname safely

## Error Handling
- Critical validations (command, path) fail the operation
- Metadata validations (shell, user, hostname) log warnings but continue

This PR depends on #38 (validation module) being merged first.

Implements validation integration for #32